### PR TITLE
Updated build-demo xcode_version to latest

### DIFF
--- a/.github/actions/build-demo/action.yml
+++ b/.github/actions/build-demo/action.yml
@@ -11,7 +11,7 @@ inputs:
   xcode_version:
     description: 'The version of Xcode to use. Ensure that your version is compatible with your selected runner. (Reference: https://swiftversion.net)'
     required: false
-    default: '13.4'
+    default: 'latest'
 runs:
   using: 'composite'
   steps:


### PR DESCRIPTION
Using "latest" will mean "the latest stable version of Xcode". This seems the best for long-term maintenance.

Like #1, this is just the default value.